### PR TITLE
Set the type of glass break sensors to 'vibration'

### DIFF
--- a/abodepy/__init__.py
+++ b/abodepy/__init__.py
@@ -439,7 +439,8 @@ def new_device(device_json, abode):
 
     if generic_type == CONST.TYPE_CONNECTIVITY or \
        generic_type == CONST.TYPE_MOISTURE or \
-       generic_type == CONST.TYPE_OPENING:
+       generic_type == CONST.TYPE_OPENING or \
+       generic_type == CONST.TYPE_VIBRATION:
         return AbodeBinarySensor(device_json, abode)
     elif generic_type == CONST.TYPE_CAMERA:
         return AbodeCamera(device_json, abode)

--- a/abodepy/helpers/constants.py
+++ b/abodepy/helpers/constants.py
@@ -136,6 +136,7 @@ TYPE_OPENING = "opening"
 TYPE_QUICK_ACTION = "quick_action"
 TYPE_SENSOR = "sensor"
 TYPE_SWITCH = "switch"
+TYPE_VIBRATION = "vibration"
 
 TYPE_UNKNOWN_SENSOR = "unknown_sensor"
 
@@ -218,8 +219,10 @@ def get_generic_type(type_tag):
         # Alarm
         DEVICE_ALARM: TYPE_ALARM,
 
+        # Binary Sensors - Vibration
+        DEVICE_GLASS_BREAK: TYPE_VIBRATION,
+
         # Binary Sensors - Connectivity
-        DEVICE_GLASS_BREAK: TYPE_CONNECTIVITY,
         DEVICE_KEYPAD: TYPE_CONNECTIVITY,
         DEVICE_REMOTE_CONTROLLER: TYPE_CONNECTIVITY,
         DEVICE_SIREN: TYPE_CONNECTIVITY,

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -235,7 +235,7 @@ class TestDevice(unittest.TestCase):
 
         # Get our glass devices
         devices = self.abode.get_devices(
-            generic_type=(CONST.TYPE_CONNECTIVITY))
+            generic_type=(CONST.TYPE_VIBRATION))
 
         self.assertIsNotNone(devices)
         self.assertEqual(len(devices), 1)
@@ -443,6 +443,7 @@ class TestDevice(unittest.TestCase):
                 CONST.TYPE_OPENING: AbodeBinarySensor,
                 CONST.TYPE_MOTION: AbodeBinarySensor,
                 CONST.TYPE_OCCUPANCY: AbodeBinarySensor,
+                CONST.TYPE_VIBRATION: AbodeBinarySensor,
 
                 # Camera
                 CONST.TYPE_CAMERA: AbodeDevice,


### PR DESCRIPTION
HA will display the vibration icon instead of connectivity for these sensors (similar to motion sensors).

This really helps when you have several sensors in the same room with just the room name (using the type to distinguish them).