### PR TITLE
Updates to make Dimmers work with HA

### DIFF
--- a/abodepy/devices/__init__.py
+++ b/abodepy/devices/__init__.py
@@ -77,11 +77,7 @@ class AbodeDevice(object):
                 raise AbodeException((ERROR.SET_STATUS_DEV_ID))
 
             if response_object['level'] != str(level):
-                """Abode returns brightness 99 when set to 100."""
-                if response_object['level'] == 99 and int(level) == 100:
-                    pass
-                else:
-                    raise AbodeException((ERROR.SET_STATUS_STATE))
+                raise AbodeException((ERROR.SET_STATUS_STATE))
 
             # TODO: Figure out where level is indicated in device json object
             self.update(response_object)

--- a/abodepy/devices/__init__.py
+++ b/abodepy/devices/__init__.py
@@ -77,7 +77,11 @@ class AbodeDevice(object):
                 raise AbodeException((ERROR.SET_STATUS_DEV_ID))
 
             if response_object['level'] != str(level):
-                raise AbodeException((ERROR.SET_STATUS_STATE))
+                """Abode returns brightness 99 when set to 100."""
+                if response_object['level'] == 99 and int(level) == 100:
+                    pass
+                else:
+                    raise AbodeException((ERROR.SET_STATUS_STATE))
 
             # TODO: Figure out where level is indicated in device json object
             self.update(response_object)

--- a/abodepy/devices/light.py
+++ b/abodepy/devices/light.py
@@ -25,7 +25,8 @@ class AbodeLight(AbodeSwitch):
     @property
     def has_brightness(self):
         """Device has brightness."""
-        return self.brightness is True
+        if self.brightness:
+            return True
 
     @property
     def has_color(self):
@@ -35,4 +36,5 @@ class AbodeLight(AbodeSwitch):
     @property
     def is_dimmable(self):
         """Device is dimmable."""
-        return self.has_brightness
+        if 'Dimmer' in self._type:
+            return True


### PR DESCRIPTION
I'm new to Python and programming but I've been working on this over the weekend and have tested it on my own setup with some changes that will have to be made to the Home Assistant (HA) Abode light component. Dimmers are working now with HA. Changes are:

- The function `is_dimmable` now returns `True` if the device type as classified by Abode is a dimmer (i.e. Dimmer and RGB Dimmer).
- The function `has_brightness` was changed such that if the device has a brightness value, it will return `True`
- When dimmers are set to 100 from HA, Abode returns a brightness value of 99 even though 100 was set causing the AbodeException error. Added some code to ignore this specific case.

I have the updates to the HA Abode light component files as well but it will require these changes to Abodepy to work.