### PR TITLE
Update lomond version to fix issue with Python 3.7.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     include_package_data=True,
     install_requires=[
         'requests>=2.12.4',
-        'lomond==0.1.14',
+        'lomond==0.3.2',
         'colorlog==3.0.1',
     ],
     test_suite='tests',


### PR DESCRIPTION
Issue with lomond and Python 3.7 that was [fixed](https://github.com/wildfoundry/dataplicity-lomond/issues/68) in version 0.3.1. Tested abodepy with the latest version of  lomond 0.3.2 with no issues.