### PR TITLE
Update device name on refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,7 @@ ENV/
 /.pydevproject
 .settings/
 *.pickle
+
+# PyCharm project settings
+.idea/
+

--- a/abodepy/devices/__init__.py
+++ b/abodepy/devices/__init__.py
@@ -125,7 +125,7 @@ class AbodeDevice(object):
         self._update_name()
 
     def _update_name(self):
-        """Sets the device name from _json_state, with a sensible default."""
+        """Set the device name from _json_state, with a sensible default."""
         self._name = self._json_state.get('name')
         if not self._name:
             self._name = self.type + ' ' + self.device_id

--- a/abodepy/devices/__init__.py
+++ b/abodepy/devices/__init__.py
@@ -18,14 +18,12 @@ class AbodeDevice(object):
         """Set up Abode device."""
         self._json_state = json_obj
         self._device_id = json_obj.get('id')
-        self._name = json_obj.get('name')
         self._type = json_obj.get('type')
         self._type_tag = json_obj.get('type_tag')
         self._generic_type = json_obj.get('generic_type')
         self._abode = abode
 
-        if not self._name:
-            self._name = self.type + ' ' + self.device_id
+        self._update_name()
 
     def set_status(self, status):
         """Set device status."""
@@ -124,6 +122,13 @@ class AbodeDevice(object):
         """
         self._json_state.update(
             {k: json_state[k] for k in json_state if self._json_state.get(k)})
+        self._update_name()
+
+    def _update_name(self):
+        """Sets the device name from _json_state, with a sensible default."""
+        self._name = self._json_state.get('name')
+        if not self._name:
+            self._name = self.type + ' ' + self.device_id
 
     @property
     def status(self):


### PR DESCRIPTION
Refreshing an AbodeDevice did not update its name if it changed.

It now uses the same logic to set the name or a default on a refresh as on initial device creation.
