### PR TITLE
Fixes motion sensor support

### DIFF
--- a/abodepy/devices/binary_sensor.py
+++ b/abodepy/devices/binary_sensor.py
@@ -14,5 +14,7 @@ class AbodeBinarySensor(AbodeDevice):
 
         Assume offline or open (worst case).
         """
-        return self.status not in (CONST.STATUS_OFF, CONST.STATUS_ONLINE,
+        if self._type == 'Occupancy':
+            return self.status not in CONST.STATUS_ONLINE
+        return self.status not in (CONST.STATUS_OFF, CONST.STATUS_OFFLINE,
                                    CONST.STATUS_CLOSED)

--- a/abodepy/devices/binary_sensor.py
+++ b/abodepy/devices/binary_sensor.py
@@ -14,5 +14,5 @@ class AbodeBinarySensor(AbodeDevice):
 
         Assume offline or open (worst case).
         """
-        return self.status not in (CONST.STATUS_OFF, CONST.STATUS_OFFLINE,
+        return self.status not in (CONST.STATUS_OFF, CONST.STATUS_ONLINE,
                                    CONST.STATUS_CLOSED)

--- a/abodepy/devices/sensor.py
+++ b/abodepy/devices/sensor.py
@@ -8,22 +8,6 @@ import abodepy.helpers.constants as CONST
 class AbodeSensor(AbodeBinarySensor):
     """Class to represent a sensor device."""
 
-    @property
-    def motion(self):
-        """Motion detected."""
-        value = self._json_state.get(CONST.MOTION_STATUS_KEY)
-        if value:
-            return int(value) == 1
-        return None
-
-    @property
-    def occupancy(self):
-        """Occupancy detected."""
-        value = self._json_state.get(CONST.OCCUPANCY_STATUS_KEY)
-        if value:
-            return int(value) == 1
-        return None
-
     def _get_status(self, key):
         return self._json_state.get(CONST.STATUSES_KEY, {}).get(key)
 

--- a/abodepy/helpers/constants.py
+++ b/abodepy/helpers/constants.py
@@ -223,9 +223,6 @@ UNIT_LUX = 'lx'
 LUX = 'lux'
 
 BRIGHTNESS_KEY = 'statusEx'
-# This is a guess currently
-MOTION_STATUS_KEY = 'motion_event'
-OCCUPANCY_STATUS_KEY = 'motion_event'
 
 
 def get_generic_type(type_tag):


### PR DESCRIPTION
1. Changing CONST.STATUS_OFFLINE to CONST.STATUS_ONLINE fixes motion sensors in Home Assistant (shows motion events).
2. The motion and property decorators were not being used and are not required to get motion status from Abode.
3. Removed constants not being used and were incorrect anyways (motion status is pulled from "statuses").