### PR TITLE
Add mac_address property for the alarm

### DIFF
--- a/abodepy/__init__.py
+++ b/abodepy/__init__.py
@@ -456,6 +456,11 @@ class Abode():
         """Get the UUID."""
         return self._cache[CONST.UUID]
 
+    @property
+    def panel(self):
+        """Return the panel json data."""
+        return self._panel
+
     def _get_session(self):
         # Perform a generic update so we know we're logged in
         self.send_request("get", CONST.PANEL_URL)

--- a/abodepy/devices/alarm.py
+++ b/abodepy/devices/alarm.py
@@ -129,3 +129,8 @@ class AbodeAlarm(AbodeSwitch):
     def is_cellular(self):
         """Return true if base station on cellular backup."""
         return int(self._json_state.get('is_cellular', '0')) == 1
+
+    @property
+    def mac_address(self):
+        """Get the hub mac address."""
+        return self._abode.panel.get('mac')


### PR DESCRIPTION
Exposes the `_panel` JSON data in the abodepy.py module as a `panel` property to be used by other modules. The alarm.py module utilizes the the `panel` property to return the mac address from the panel JSON.