### PR TITLE
Release/0.16.2

### DIFF
--- a/abodepy/__init__.py
+++ b/abodepy/__init__.py
@@ -456,11 +456,6 @@ class Abode():
         """Get the UUID."""
         return self._cache[CONST.UUID]
 
-    @property
-    def panel(self):
-        """Return the panel json data."""
-        return self._panel
-
     def _get_session(self):
         # Perform a generic update so we know we're logged in
         self.send_request("get", CONST.PANEL_URL)

--- a/abodepy/devices/__init__.py
+++ b/abodepy/devices/__init__.py
@@ -191,5 +191,6 @@ class AbodeDevice():
     def desc(self):
         """Get a short description of the device."""
         # Garage Entry Door (ZW:00000003) - Door Lock - Closed
-        return '{0} (ID: {1}) - {2} - {3}'.format(
-            self.name, self.device_id, self.type, self.status)
+        return '{0} (ID: {1}, UUID: {2}) - {3} - {4}'.format(
+            self.name, self.device_id, self.device_uuid,
+            self.type, self.status)

--- a/abodepy/devices/alarm.py
+++ b/abodepy/devices/alarm.py
@@ -18,6 +18,7 @@ def create_alarm(panel_json, abode, area='1'):
     panel_json['type'] = CONST.ALARM_TYPE
     panel_json['type_tag'] = CONST.DEVICE_ALARM
     panel_json['generic_type'] = CONST.TYPE_ALARM
+    panel_json['uuid'] = panel_json.get('mac').replace(':', '').lower()
 
     return AbodeAlarm(panel_json, abode, area)
 

--- a/abodepy/devices/alarm.py
+++ b/abodepy/devices/alarm.py
@@ -134,4 +134,4 @@ class AbodeAlarm(AbodeSwitch):
     @property
     def mac_address(self):
         """Get the hub mac address."""
-        return self._abode.panel.get('mac')
+        return self._json_state.get('mac')

--- a/abodepy/helpers/constants.py
+++ b/abodepy/helpers/constants.py
@@ -3,7 +3,7 @@ import os
 
 MAJOR_VERSION = 0
 MINOR_VERSION = 16
-PATCH_VERSION = '1'
+PATCH_VERSION = '2'
 
 __version__ = '{}.{}.{}'.format(MAJOR_VERSION, MINOR_VERSION, PATCH_VERSION)
 
@@ -29,7 +29,7 @@ PROJECT_CLASSIFIERS = [
     'Intended Audience :: Developers',
     'License :: OSI Approved :: MIT License',
     'Operating System :: OS Independent',
-    'Programming Language :: Python :: 3.4',
+    'Programming Language :: Python :: 3.5',
     'Topic :: Home Automation'
 ]
 

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,4 +1,4 @@
-flake8==3.3
+flake8>=3.6.0
 flake8-docstrings==1.1.0
 pylint==2.4.2
 pydocstyle==2.0.0

--- a/tests/mock/devices/alarm.py
+++ b/tests/mock/devices/alarm.py
@@ -19,5 +19,6 @@ def device(area='1', panel=PANEL.get_response_ok(mode=CONST.MODE_STANDBY)):
     alarm['type'] = CONST.ALARM_TYPE
     alarm['type_tag'] = CONST.DEVICE_ALARM
     alarm['generic_type'] = CONST.TYPE_ALARM
+    alarm['uuid'] = alarm.get('mac').replace(':', '').lower()
 
     return alarm

--- a/tests/mock/devices/glass.py
+++ b/tests/mock/devices/glass.py
@@ -6,7 +6,8 @@ DEVICE_ID = 'RF:00000001'
 
 def device(devid=DEVICE_ID, status=CONST.STATUS_ONLINE,
            low_battery=False, no_response=False,
-           out_of_order=False, tampered=False):
+           out_of_order=False, tampered=False,
+           uuid='91568b0d4c9d58c10d75fdeea887d4f4'):
     """Glass break sensor mock device."""
     return '''
         {
@@ -53,5 +54,6 @@ def device(devid=DEVICE_ID, status=CONST.STATUS_ONLINE,
           ],
           "status_icons":[
           ],
-          "icon":"assets/icons/unknown.svg"
+          "icon":"assets/icons/unknown.svg",
+          "uuid":"''' + uuid + '''"
        }'''

--- a/tests/mock/panel.py
+++ b/tests/mock/panel.py
@@ -3,7 +3,8 @@
 import abodepy.helpers.constants as CONST
 
 
-def get_response_ok(mode=CONST.MODE_STANDBY, battery=False, is_cellular=False):
+def get_response_ok(mode=CONST.MODE_STANDBY, battery=False, is_cellular=False,
+                    mac='00:11:22:33:44:55'):
     """Return panel response json."""
     return '''{
        "version":"ABGW 0.0.2.17F ABGW-L1-XA36J 3.1.2.6.1 Z-Wave 3.95",
@@ -38,6 +39,19 @@ def get_response_ok(mode=CONST.MODE_STANDBY, battery=False, is_cellular=False):
        "plan_set_id":"1",
        "dealer_id":"0",
        "tz_diff":"-04:00",
+       "is_demo":"0",
+       "rf51_version":"ABGW-L1-XA36J",
+       "model":"L1",
+       "mac":"''' + mac + '''",
+       "xml_version":"3",
+       "dealer_name":"abode",
+       "id":"0",
+       "dealer_address":"2625 Middlefield Road #900 Palo Alto CA 94306",
+       "dealer_domain":"https://my.goabode.com",
+       "domain_alias":"https://test.goabode.com",
+       "dealer_support_url":"https://support.goabode.com",
+       "app_launch_url":"https://goabode.app.link/abode",
+       "has_wifi":"0",
        "mode":{
           "area_1":"''' + mode + '''",
           "area_2":"standby"

--- a/tests/test_alarm.py
+++ b/tests/test_alarm.py
@@ -56,7 +56,8 @@ class TestAlarm(unittest.TestCase):
         m.get(CONST.OAUTH_TOKEN_URL, text=OAUTH_CLAIMS.get_response_ok())
         m.post(CONST.LOGOUT_URL, text=LOGOUT.post_response_ok())
         m.get(CONST.PANEL_URL, text=PANEL.get_response_ok(
-            mode=CONST.MODE_STANDBY, battery=True, is_cellular=True))
+            mode=CONST.MODE_STANDBY, battery=True, is_cellular=True,
+            mac='01:AA:b3:C4:d5:66'))
         m.get(CONST.DEVICES_URL, text=DEVICES.EMPTY_DEVICE_RESPONSE)
 
         # Logout to reset everything
@@ -70,6 +71,8 @@ class TestAlarm(unittest.TestCase):
         self.assertTrue(alarm.battery)
         self.assertTrue(alarm.is_cellular)
         self.assertFalse(alarm.is_on)
+        self.assertEqual(alarm.device_uuid, '01aab3c4d566')
+        self.assertEqual(alarm.mac_address, '01:AA:b3:C4:d5:66')
 
         # Change alarm properties and state to away and test
         m.get(CONST.PANEL_URL, text=PANEL.get_response_ok(

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -112,7 +112,8 @@ class TestDevice(unittest.TestCase):
         device_text = '[' + GLASS.device(
             status=CONST.STATUS_ONLINE,
             low_battery=True, no_response=True,
-            tampered=True, out_of_order=True) + ']'
+            tampered=True, out_of_order=True,
+            uuid='testuuid00000001') + ']'
         device_json = json.loads(device_text)
 
         m.get(CONST.DEVICES_URL, text=device_text)
@@ -130,6 +131,7 @@ class TestDevice(unittest.TestCase):
         self.assertEqual(device.type, device_json[0]['type'])
         self.assertEqual(device.type_tag, device_json[0]['type_tag'])
         self.assertEqual(device.device_id, device_json[0]['id'])
+        self.assertEqual(device.device_uuid, device_json[0]['uuid'])
         self.assertEqual(device.status, CONST.STATUS_ONLINE)
         self.assertTrue(device.battery_low)
         self.assertTrue(device.no_response)


### PR DESCRIPTION
- Alarm devices create a UUID based on the mac address
- Alarm devices can provide the raw mac address using internal state
- Added tests for device UUID and mac addresses
- Fixed some remaining py37 support issues
- Version bump to 0.16.2