### PR TITLE
Add ability to remove device callback

### DIFF
--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -67,9 +67,34 @@ class AbodeEventController():
                 raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
 
             _LOGGER.debug(
-                "Subscribing to updated for device_id: %s", device_id)
+                "Subscribing to updates for device_id: %s", device_id)
 
             self._device_callbacks[device_id].append((callback))
+
+        return True
+
+    def remove_device_callback(self, devices):
+        """Unregister a device callback."""
+        if not devices:
+            return False
+
+        if not isinstance(devices, (tuple, list)):
+            devices = [devices]
+
+        for device in devices:
+            device_id = device
+
+            if isinstance(device, AbodeDevice):
+                device_id = device.device_id
+
+            if not self._abode.get_device(device_id):
+                raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
+
+            _LOGGER.debug(
+                "Unsubscribing from updates for device_id: %s", device_id)
+
+            if device_id in self._device_callbacks:
+                del self._device_callbacks[device_id]
 
         return True
 


### PR DESCRIPTION
Need the ability to remove a device callback for Home Assistant entity registry when a device is disabled via the UI. Implementation is essentially the same as `add_device_callback`, however there isn't a need to pass in the actual callback since we're simply removing the `device_id` key from `self._device_callbacks`.