### PR TITLE
Fix for hue logging issue

### DIFF
--- a/abodepy/devices/light.py
+++ b/abodepy/devices/light.py
@@ -76,11 +76,10 @@ class AbodeLight(AbodeSwitch):
                 raise AbodeException((ERROR.SET_STATUS_DEV_ID))
 
             # Abode will sometimes return hue value off by 1 (rounding error)
-            if not (
-                    math.isclose(response_object["hue"], int(hue), abs_tol=1)
-                    or response_object["saturation"] == int(saturation)
-            ):
-
+            hue_comparison = math.isclose(response_object["hue"],
+                                          int(hue), abs_tol=1)
+            if not hue_comparison or (response_object["saturation"]
+                                      != int(saturation)):
                 _LOGGER.warning(
                     ("Set color mismatch for device %s. "
                      "Request val: %s, Response val: %s "),

--- a/abodepy/devices/light.py
+++ b/abodepy/devices/light.py
@@ -78,7 +78,7 @@ class AbodeLight(AbodeSwitch):
             # Abode will sometimes return hue value off by 1 (rounding error)
             if not (
                     math.isclose(response_object["hue"], int(hue), abs_tol=1)
-                    or response_object["saturation"] != int(saturation)
+                    or response_object["saturation"] == int(saturation)
             ):
 
                 _LOGGER.warning(

--- a/abodepy/devices/light.py
+++ b/abodepy/devices/light.py
@@ -1,6 +1,7 @@
 """Abode light device."""
 import json
 import logging
+import math
 
 from abodepy.exceptions import AbodeException
 
@@ -74,8 +75,12 @@ class AbodeLight(AbodeSwitch):
             if response_object['idForPanel'] != self.device_id:
                 raise AbodeException((ERROR.SET_STATUS_DEV_ID))
 
-            if (response_object['hue'] != int(hue) or
-                    response_object['saturation'] != int(saturation)):
+            # Abode will sometimes return hue value off by 1 (rounding error)
+            if not (
+                    math.isclose(response_object["hue"], int(hue), abs_tol=1)
+                    or response_object["saturation"] != int(saturation)
+            ):
+
                 _LOGGER.warning(
                     ("Set color mismatch for device %s. "
                      "Request val: %s, Response val: %s "),


### PR DESCRIPTION
When changing the color of a light, Abode will sometimes return a hue value that is off by 1 resulting in a warning log message, "Set color mismatch for device...". In an attempt to reduce unnecessary logging messages (mostly to reduce extraneous logging messages in Home Assistant), this pull request makes a slight modification to the comparison of the requested and response object hue value using the math standard library. The `isclose` method (added in Python 3.5) is used with `abs_tol` set to `1`. This way, if the values are ever anything greater than 1.0, the warning log message will appear, which shouldn't happen unless something is really off. If the values are equal to or less than 1.0, the warning log message will not appear. I've only seen this "issue" with the hue value, hence the reason I only made the change there.

Edit: Just spent more time than I'd like to admit on confusion with the `or`  operator. The parenthesis around the entire `if` statement led me down the wrong path, then trying to format the code so the line wasn't too long confused me even more. It should be correct now.

`math.isclose(response_object["hue"], int(hue), abs_tol=1)` will return `True` if the difference between the hue values are less than or equal to 1.

So basically my logic is, if not true (i.e. the difference between the hue values are greater than 1) or the saturation values don't match, then log the warning. Clear as mud.... I need some sleep.