### PR TITLE
Add callback for abode connection status

### DIFF
--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -61,13 +61,13 @@ class AbodeEventController():
         for device in devices:
             device_id = device
 
-            if isinstance(device, (AbodeDevice)):
+            if isinstance(device, AbodeDevice):
                 device_id = device.device_id
 
                 if not self._abode.get_device(device_id):
                     raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
 
-            if isinstance(device, (AbodeAutomation)):
+            if isinstance(device, AbodeAutomation):
                 device_id = device.automation_id
 
                 if not self._abode.get_automation(device_id):

--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -74,9 +74,42 @@ class AbodeEventController():
                     raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
 
             _LOGGER.debug(
-                "Subscribing to Abode connection updates for device_id: %s", device_id)
+                "Subscribing to Abode connection updates for: %s", device_id)
 
         self._connection_status_callbacks[device_id].append((callback))
+
+        return True
+
+    def remove_connection_status_callback(self, devices):
+        """Unregister connection status callbacks."""
+        if not devices:
+            return False
+
+        if not isinstance(devices, (tuple, list)):
+            devices = [devices]
+
+        for device in devices:
+            device_id = device
+
+            if isinstance(device, AbodeDevice):
+                device_id = device.device_id
+
+                if not self._abode.get_device(device_id):
+                    raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
+
+            if isinstance(device, AbodeAutomation):
+                device_id = device.automation_id
+
+                if not self._abode.get_automation(device_id):
+                    raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
+
+            if device_id not in self._connection_status_callbacks:
+                return False
+
+            _LOGGER.debug(
+                "Unsubscribing from Abode connection updates for : %s", device_id)
+
+            self._connection_status_callbacks[device_id].clear()
 
         return True
 
@@ -131,8 +164,6 @@ class AbodeEventController():
                 "Unsubscribing from all updates for device_id: %s", device_id)
 
             self._device_callbacks[device_id].clear()
-
-            self._connection_status_callbacks[device_id].clear()
 
         return True
 

--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -20,7 +20,7 @@ class AbodeEventController():
         self._abode = abode
         self._thread = None
         self._running = False
-        self._is_connected = False
+        self._connected = False
 
         # Setup callback dicts
         self._connection_status_callbacks = []
@@ -50,7 +50,9 @@ class AbodeEventController():
         self._socketio.stop()
 
     def add_connection_status_callback(self, callback):
-        """Add an Abode server connection status callback."""
+        """Register callback for Abode server connection status."""
+        # All callback in the list `_connection_status_callbacks` are
+        # called when the web socket is connected or disconnected
         self._connection_status_callbacks.append(callback)
 
         return True
@@ -152,9 +154,9 @@ class AbodeEventController():
         return True
 
     @property
-    def is_connected(self):
+    def connected(self):
         """Get the Abode connection status."""
-        return self._is_connected
+        return self._connected
 
     @property
     def socketio(self):
@@ -172,7 +174,7 @@ class AbodeEventController():
 
     def _on_socket_connected(self):
         """Socket IO connected callback."""
-        self._is_connected = True
+        self._connected = True
 
         self._abode.refresh()
 
@@ -181,7 +183,7 @@ class AbodeEventController():
 
     def _on_socket_disconnected(self):
         """Socket IO disconnected callback."""
-        self._is_connected = False
+        self._connected = False
 
         for callback in self._connection_status_callbacks:
             _execute_callback(callback)

--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -50,66 +50,27 @@ class AbodeEventController():
         """Tell the subscription thread to terminate - will block."""
         self._socketio.stop()
 
-    def add_connection_status_callback(self, devices, callback):
+    def add_connection_status_callback(self, unique_id, callback):
         """Register callback for Abode server connection status."""
-        if not devices:
+        if not unique_id:
             return False
 
-        if not isinstance(devices, (tuple, list)):
-            devices = [devices]
+        _LOGGER.debug(
+            "Subscribing to Abode connection updates for: %s", unique_id)
 
-        for device in devices:
-            device_id = device
-
-            if isinstance(device, AbodeDevice):
-                device_id = device.device_id
-
-                if not self._abode.get_device(device_id):
-                    raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
-
-            if isinstance(device, AbodeAutomation):
-                device_id = device.automation_id
-
-                if not self._abode.get_automation(device_id):
-                    raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
-
-            _LOGGER.debug(
-                "Subscribing to Abode connection updates for: %s", device_id)
-
-        self._connection_status_callbacks[device_id].append((callback))
+        self._connection_status_callbacks[unique_id].append((callback))
 
         return True
 
-    def remove_connection_status_callback(self, devices):
+    def remove_connection_status_callback(self, unique_id):
         """Unregister connection status callbacks."""
-        if not devices:
+        if not unique_id:
             return False
 
-        if not isinstance(devices, (tuple, list)):
-            devices = [devices]
+        _LOGGER.debug(
+            "Unsubscribing from Abode connection updates for : %s", unique_id)
 
-        for device in devices:
-            device_id = device
-
-            if isinstance(device, AbodeDevice):
-                device_id = device.device_id
-
-                if not self._abode.get_device(device_id):
-                    raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
-
-            if isinstance(device, AbodeAutomation):
-                device_id = device.automation_id
-
-                if not self._abode.get_automation(device_id):
-                    raise AbodeException((ERROR.EVENT_DEVICE_INVALID))
-
-            if device_id not in self._connection_status_callbacks:
-                return False
-
-            _LOGGER.debug(
-                "Unsubscribing from Abode connection updates for : %s", device_id)
-
-            self._connection_status_callbacks[device_id].clear()
+        self._connection_status_callbacks[unique_id].clear()
 
         return True
 

--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -23,7 +23,7 @@ class AbodeEventController():
         self._is_connected = False
 
         # Setup callback dicts
-        self._abode_status_callback = []
+        self._connection_status_callbacks = []
         self._device_callbacks = collections.defaultdict(list)
         self._event_callbacks = collections.defaultdict(list)
         self._timeline_callbacks = collections.defaultdict(list)
@@ -51,7 +51,7 @@ class AbodeEventController():
 
     def add_connection_status_callback(self, callback):
         """Add an Abode server connection status callback."""
-        self._abode_status_callback.append(callback)
+        self._connection_status_callbacks.append(callback)
 
         return True
 
@@ -176,14 +176,14 @@ class AbodeEventController():
 
         self._abode.refresh()
 
-        for callback in self._abode_status_callback:
+        for callback in self._connection_status_callbacks:
             _execute_callback(callback)
 
     def _on_socket_disconnected(self):
         """Socket IO disconnected callback."""
         self._is_connected = False
 
-        for callback in self._abode_status_callback:
+        for callback in self._connection_status_callbacks:
             _execute_callback(callback)
 
     def _on_device_update(self, devid):


### PR DESCRIPTION
~~This is a work in progress but I wanted to make this PR to be able to get some feedback.~~ I'm attempting to add support for setting the entity `available` property in Home Assistant for abode devices/automations. Basically, when `available` is `True`, the entities are available to use and when `False`, the entities are greyed out in the HA UI and can't be used. Here's an overview on my initial thought at implementation:

- Use the existing `_on_socket_connect` and `_on_socket_disconnect` callbacks in the `AbodeEventController` class in event_controller.py. These are called when the web socket connection to the Abode server is connected and disconnected.
- Create a new property `self._is_connected` on the `AbodeEventController` that is set to `False` by default. This will `True` when `_on_socket_connect` is called and `False` when `_on_socket_disconnect` is called. A property method `is_connected` is also created to return `self._is_connected` for accessing outside the class.
- Create a new method `add_connection_status_callback` that appends callbacks to a newly added empty list `self._connection_status_callback`.

From the Home Assistant side, I'm simply calling `add_connection_status_callback` for each instance of `AbodeDevice` (in the abode HA integration). This in turn adds a simple callback method:
```
    def _update_connection_status(self):
        """Update the device available property."""
        self._available = self._data.abode.events.connected
        self.schedule_update_ha_state()
```

When `_on_socket_connect` is called, it will call the callback above for every Abode device in Home Assistant which will set the `self._available` property based on the `self._is_connected` boolean.

Everything is working as expected during testing but I'd like to get some other opinions.


