### PR TITLE
Add ability to turn camera on/off and is_on property

### DIFF
--- a/abodepy/devices/camera.py
+++ b/abodepy/devices/camera.py
@@ -123,12 +123,9 @@ class AbodeCamera(AbodeDevice):
             url = CONST.PARAMS_URL + self.device_id
 
             camera_data = {
-                'name': self.name,
                 'mac': self._json_state['camera_mac'],
                 'privacy': privacy,
                 'action': 'setParam',
-                'area': '1',
-                'no': '1',
                 'id': self.device_id
             }
 

--- a/abodepy/devices/camera.py
+++ b/abodepy/devices/camera.py
@@ -115,7 +115,47 @@ class AbodeCamera(AbodeDevice):
 
         return True
 
+    def privacy_mode(self, enable):
+        """Set camera privacy mode (camera on/off)."""
+        if self._json_state['privacy']:
+            privacy = '0' if enable else '1'
+
+            url = CONST.PARAMS_URL + self.device_id
+
+            camera_data = {
+                'name': self.name,
+                'mac': self._json_state['camera_mac'],
+                'privacy': privacy,
+                'action': 'setParam',
+                'area': '1',
+                'no': '1',
+                'id': self.device_id
+            }
+
+            response = self._abode.send_request(
+                method="put", url=url, data=camera_data)
+            response_object = json.loads(response.text)
+
+            _LOGGER.debug("Camera Privacy Mode Response: %s", response.text)
+
+            if response_object['id'] != self.device_id:
+                raise AbodeException((ERROR.SET_STATUS_DEV_ID))
+
+            if response_object['privacy'] != str(privacy):
+                raise AbodeException((ERROR.SET_PRIVACY_MODE))
+
+            _LOGGER.info("Set camera %s privacy mode to: %s", self.device_id, privacy)
+
+            return True
+
+        return False
+
     @property
     def image_url(self):
         """Get image URL."""
         return self._image_url
+
+    @property
+    def is_on(self):
+        """Get camera state (assumed on)."""
+        return self.status not in (CONST.STATUS_OFF, CONST.STATUS_OFFLINE)

--- a/abodepy/helpers/constants.py
+++ b/abodepy/helpers/constants.py
@@ -53,6 +53,8 @@ LOGOUT_URL = BASE_URL + 'api/v1/logout'
 
 OAUTH_TOKEN_URL = BASE_URL + 'api/auth2/claims'
 
+PARAMS_URL = BASE_URL + 'api/v1/devices_beta/'
+
 PANEL_URL = BASE_URL + 'api/v1/panel'
 
 INTEGRATIONS_URL = BASE_URL + 'integrations/v1/devices/'

--- a/abodepy/helpers/errors.py
+++ b/abodepy/helpers/errors.py
@@ -40,8 +40,8 @@ INVALID_AUTOMATION_REFRESH_RESPONSE = (
 INVALID_AUTOMATION_EDIT_RESPONSE = (
     16, "Automation edit response did not match expected values.")
 
-# TRIGGER_NON_QUICKACTION = (
-#     17, "Can not trigger an automation that is not a manual quick-action.")
+SET_PRIVACY_MODE = (
+    17, "Device privacy mode value does not match request value.")
 
 UNABLE_TO_MAP_DEVICE = (
     18, "Unable to map device json to device class - no type tag found.")

--- a/abodepy/helpers/errors.py
+++ b/abodepy/helpers/errors.py
@@ -40,8 +40,9 @@ INVALID_AUTOMATION_REFRESH_RESPONSE = (
 INVALID_AUTOMATION_EDIT_RESPONSE = (
     16, "Automation edit response did not match expected values.")
 
-SET_PRIVACY_MODE = (
-    17, "Device privacy mode value does not match request value.")
+# DEPRECATED
+# TRIGGER_NON_QUICKACTION = (
+#     17, "Can not trigger an automation that is not a manual quick-action.")
 
 UNABLE_TO_MAP_DEVICE = (
     18, "Unable to map device json to device class - no type tag found.")
@@ -81,3 +82,6 @@ SOCKETIO_ERROR = (
 
 MISSING_CONTROL_URL = (
     30, "Control URL does not exist in device JSON.")
+
+SET_PRIVACY_MODE = (
+    31, "Device privacy mode value does not match request value.")

--- a/tests/mock/devices/ipcam.py
+++ b/tests/mock/devices/ipcam.py
@@ -7,7 +7,7 @@ CONTROL_URL_SNAPSHOT = 'api/v1/cams/' + DEVICE_ID + '/capture'
 
 
 def device(devid=DEVICE_ID, status=CONST.STATUS_ONLINE,
-           low_battery=False, no_response=False):
+           low_battery=False, no_response=False, privacy=1):
     """IP camera mock device."""
     return '''
         {
@@ -88,7 +88,7 @@ def device(devid=DEVICE_ID, status=CONST.STATUS_ONLINE,
           "is_new_camera": 1,
           "stream_quality": 3,
           "camera_mac": "AB:CD:EF:GF:HI",
-          "privacy": "1",
+          "privacy":"''' + str(privacy) + '''",
           "enable_audio": "1",
           "alarm_video": "25",
           "pre_alarm_video": "5",


### PR DESCRIPTION
Added the ability to turn the camera on/off and the `is_on` property. This is to support a PR I'm making for the Abode component in Home Assistant to add the functionality to call the camera on/off service.