### PR TITLE
Fix for camera privacy mode

### DIFF
--- a/abodepy/devices/camera.py
+++ b/abodepy/devices/camera.py
@@ -118,7 +118,7 @@ class AbodeCamera(AbodeDevice):
     def privacy_mode(self, enable):
         """Set camera privacy mode (camera on/off)."""
         if self._json_state['privacy']:
-            privacy = '0' if enable else '1'
+            privacy = '1' if enable else '0'
 
             url = CONST.PARAMS_URL + self.device_id
 

--- a/tests/test_camera.py
+++ b/tests/test_camera.py
@@ -361,14 +361,14 @@ class TestCamera(unittest.TestCase):
 
         # Set up params URL response for privacy mode on
         m.put(CONST.PARAMS_URL + device.device_id,
-              text=IPCAM.device(privacy=0))
+              text=IPCAM.device(privacy=1))
 
         # Set privacy mode on
         self.assertTrue(device.privacy_mode(True))
 
         # Set up params URL response for privacy mode off
         m.put(CONST.PARAMS_URL + device.device_id,
-              text=IPCAM.device(privacy=1))
+              text=IPCAM.device(privacy=0))
 
         # Set privacy mode off
         self.assertTrue(device.privacy_mode(False))


### PR DESCRIPTION
`privacy_mode(true)` should pass the string `1` and `privacy_mode(false)` should pass the string `0`. I had it backwards but this PR fixes it.