### PR TITLE
Fix to handle Abode server issues

### DIFF
--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -199,7 +199,7 @@ class AbodeEventController():
             _LOGGER.warning("Captured exception during Abode refresh: %s", exc)
         finally:
             # Callbacks should still execute even if refresh fails (Abode server
-            # issues) so that the entity availability in Home Assistant is updated 
+            # issues) so that the entity availability in Home Assistant is updated
             # since we are in fact connected to the web socket.
             for callbacks in self._connection_status_callbacks.items():
                 for callback in callbacks[1]:

--- a/abodepy/event_controller.py
+++ b/abodepy/event_controller.py
@@ -192,11 +192,18 @@ class AbodeEventController():
         """Socket IO connected callback."""
         self._connected = True
 
-        self._abode.refresh()
-
-        for callbacks in self._connection_status_callbacks.items():
-            for callback in callbacks[1]:
-                _execute_callback(callback)
+        try:
+            self._abode.refresh()
+        # pylint: disable=W0703
+        except Exception as exc:
+            _LOGGER.warning("Captured exception during Abode refresh: %s", exc)
+        finally:
+            # Callbacks should still execute even if refresh fails (Abode server
+            # issues) so that the entity availability in Home Assistant is updated 
+            # since we are in fact connected to the web socket.
+            for callbacks in self._connection_status_callbacks.items():
+                for callback in callbacks[1]:
+                    _execute_callback(callback)
 
     def _on_socket_disconnected(self):
         """Socket IO disconnected callback."""


### PR DESCRIPTION
An [issue](https://github.com/home-assistant/core/issues/38136) was identified with the Abode component in Home Assistant where entities are sometimes stuck in an "Unavailable" state after the web socket is disconnected. What appears to be occurring is sometimes the web socket reconnects, `_on_socket_connected` is called which then calls `self._abode.refresh()`. However, the issue is this refresh will sometimes throw an exception because the response is not correct (Abode server is probably still initializing) which then stops the callbacks from executing. For the Home Assistant Abode component, we still want these callbacks to execute since the web socket is connected.

Solution is to execute a try block here and execute the callbacks in the finally section such that they always execute since `self._connected` is in fact `True`.