### PR TITLE
Add MFA support

### DIFF
--- a/abodepy/__init__.py
+++ b/abodepy/__init__.py
@@ -93,7 +93,7 @@ class Abode():
             self._cache[CONST.PASSWORD] = password
 
         self._save_cache()
-        
+
         # Load persisted cookies (which contains the UUID and the session ID)
         # if available
         if (CONST.COOKIES in self._cache and
@@ -135,7 +135,7 @@ class Abode():
             CONST.PASSWORD: self._cache[CONST.PASSWORD],
             CONST.UUID: self._cache[CONST.UUID]
         }
-        
+
         if mfa_code is not None:
             login_data[CONST.MFA_CODE] = mfa_code
             login_data['remember_me'] = 1
@@ -147,7 +147,7 @@ class Abode():
                                                 response.text))
 
         response_object = json.loads(response.text)
-        
+
         if response_object.get('mfa_type', None) == "google_authenticator":
             raise AbodeAuthenticationException(ERROR.MFA_CODE_REQUIRED)
 

--- a/abodepy/__init__.py
+++ b/abodepy/__init__.py
@@ -76,7 +76,8 @@ class Abode():
         self._cache = {
             CONST.ID: None,
             CONST.PASSWORD: None,
-            CONST.UUID: UTILS.gen_uuid()
+            CONST.UUID: UTILS.gen_uuid(),
+            CONST.COOKIES: None
         }
 
         # Load and merge an existing cache
@@ -92,6 +93,12 @@ class Abode():
             self._cache[CONST.PASSWORD] = password
 
         self._save_cache()
+        
+        # Load persisted cookies (which contains the UUID and the session ID)
+        # if available
+        if (CONST.COOKIES in self._cache and
+                self._cache[CONST.COOKIES] is not None):
+            self._session.cookies = self._cache[CONST.COOKIES]
 
         if (self._cache[CONST.ID] is not None and
                 self._cache[CONST.PASSWORD] is not None and
@@ -104,7 +111,7 @@ class Abode():
         if get_automations:
             self.get_automations()
 
-    def login(self, username=None, password=None):
+    def login(self, username=None, password=None, mfa_code=None):
         """Explicit Abode login."""
         if username is not None:
             self._cache[CONST.ID] = username
@@ -128,6 +135,10 @@ class Abode():
             CONST.PASSWORD: self._cache[CONST.PASSWORD],
             CONST.UUID: self._cache[CONST.UUID]
         }
+        
+        if mfa_code is not None:
+            login_data[CONST.MFA_CODE] = mfa_code
+            login_data['remember_me'] = 1
 
         response = self._session.post(CONST.LOGIN_URL, json=login_data)
 
@@ -136,6 +147,14 @@ class Abode():
                                                 response.text))
 
         response_object = json.loads(response.text)
+        
+        if response_object.get('mfa_type', None) == "google_authenticator":
+            raise AbodeAuthenticationException(ERROR.MFA_CODE_REQUIRED)
+
+        # Persist cookies (which contains the UUID and the session ID) to disk
+        if self._session.cookies.get_dict():
+            self._cache[CONST.COOKIES] = self._session.cookies
+            self._save_cache()
 
         oauth_response = self._session.get(CONST.OAUTH_TOKEN_URL)
 

--- a/abodepy/__init__.py
+++ b/abodepy/__init__.py
@@ -148,8 +148,11 @@ class Abode():
 
         response_object = json.loads(response.text)
 
-        if response_object.get('mfa_type', None) == "google_authenticator":
-            raise AbodeAuthenticationException(ERROR.MFA_CODE_REQUIRED)
+        if 'mfa_type' in response_object:
+            if response_object['mfa_type'] == "google_authenticator":
+                raise AbodeAuthenticationException(ERROR.MFA_CODE_REQUIRED)
+            else:
+                raise AbodeAuthenticationException(ERROR.UNKNOWN_MFA_TYPE)
 
         # Persist cookies (which contains the UUID and the session ID) to disk
         if self._session.cookies.get_dict():

--- a/abodepy/__main__.py
+++ b/abodepy/__main__.py
@@ -76,7 +76,7 @@ def get_arguments():
         '-p', '--password',
         help='Password',
         required=False)
-        
+
     parser.add_argument(
         '--mfa',
         help='Multifactor authentication code',
@@ -234,11 +234,11 @@ def call():
             abode = abodepy.Abode(username=args.username,
                                   password=args.password,
                                   get_devices=args.mfa is None)
-        
-        # Since the MFA code is very time sensitive, if the user has provided one
-        # we should use it to log in as soon as possible
+
+        # Since the MFA code is very time sensitive, if the user has provided
+        # one we should use it to log in as soon as possible
         if args.mfa:
-            abode.login(mfa_code = args.mfa)
+            abode.login(mfa_code=args.mfa)
             # Now we can fetch devices from Abode
             abode.get_devices()
 

--- a/abodepy/__main__.py
+++ b/abodepy/__main__.py
@@ -76,6 +76,11 @@ def get_arguments():
         '-p', '--password',
         help='Password',
         required=False)
+        
+    parser.add_argument(
+        '--mfa',
+        help='Multifactor authentication code',
+        required=False)
 
     parser.add_argument(
         '--cache',
@@ -220,15 +225,22 @@ def call():
         if args.cache and args.username and args.password:
             abode = abodepy.Abode(username=args.username,
                                   password=args.password,
-                                  get_devices=True,
+                                  get_devices=args.mfa is None,
                                   cache_path=args.cache)
         elif args.cache and not (not args.username or not args.password):
-            abode = abodepy.Abode(get_devices=True,
+            abode = abodepy.Abode(get_devices=args.mfa is None,
                                   cache_path=args.cache)
         else:
             abode = abodepy.Abode(username=args.username,
                                   password=args.password,
-                                  get_devices=True)
+                                  get_devices=args.mfa is None)
+        
+        # Since the MFA code is very time sensitive, if the user has provided one
+        # we should use it to log in as soon as possible
+        if args.mfa:
+            abode.login(mfa_code = args.mfa)
+            # Now we can fetch devices from Abode
+            abode.get_devices()
 
         # Output current mode.
         if args.mode:

--- a/abodepy/helpers/constants.py
+++ b/abodepy/helpers/constants.py
@@ -40,10 +40,12 @@ PROJECT_GITHUB_REPOSITORY = 'abodepy'
 PYPI_URL = 'https://pypi.python.org/pypi/{}'.format(PROJECT_PACKAGE_NAME)
 
 CACHE_PATH = './abode.pickle'
+COOKIES = "cookies"
 
 ID = 'id'
 PASSWORD = 'password'
 UUID = 'uuid'
+MFA_CODE = 'mfa_code'
 
 # URLS
 BASE_URL = 'https://my.goabode.com/'

--- a/abodepy/helpers/errors.py
+++ b/abodepy/helpers/errors.py
@@ -88,3 +88,6 @@ SET_PRIVACY_MODE = (
 
 MFA_CODE_REQUIRED = (
     32, "Multifactor authentication code required for login.")
+
+UNKNOWN_MFA_TYPE = (
+    33, "Unknown multifactor authentication type.")

--- a/abodepy/helpers/errors.py
+++ b/abodepy/helpers/errors.py
@@ -85,6 +85,6 @@ MISSING_CONTROL_URL = (
 
 SET_PRIVACY_MODE = (
     31, "Device privacy mode value does not match request value.")
-    
+
 MFA_CODE_REQUIRED = (
     32, "Multifactor authentication code required for login.")

--- a/abodepy/helpers/errors.py
+++ b/abodepy/helpers/errors.py
@@ -85,3 +85,6 @@ MISSING_CONTROL_URL = (
 
 SET_PRIVACY_MODE = (
     31, "Device privacy mode value does not match request value.")
+    
+MFA_CODE_REQUIRED = (
+    32, "Multifactor authentication code required for login.")

--- a/tests/mock/login.py
+++ b/tests/mock/login.py
@@ -69,3 +69,12 @@ def post_response_bad_mfa_code():
             "code":400,"message":"Invalid authentication key.",
             "detail":null
         }'''
+
+
+def post_response_unknown_mfa_type():
+    """Return a login response json with an unknown mfa type."""
+    return '''
+        {
+            "code":200,"mfa_type":"sms",
+            "detail":null
+        }'''

--- a/tests/mock/login.py
+++ b/tests/mock/login.py
@@ -51,3 +51,21 @@ def post_response_bad_request():
             "code":400,"message":"Username and password do not match.",
             "detail":null
         }'''
+
+
+def post_response_mfa_code_required():
+    """Return the MFA code required login response json."""
+    return '''
+        {
+            "code":200,"mfa_type":"google_authenticator",
+            "detail":null
+        }'''
+
+
+def post_response_bad_mfa_code():
+    """Return the bad MFA code login response json."""
+    return '''
+        {
+            "code":400,"message":"Invalid authentication key.",
+            "detail":null
+        }'''

--- a/tests/test_abode.py
+++ b/tests/test_abode.py
@@ -192,6 +192,17 @@ class TestAbode(unittest.TestCase):
                                      mfa_code=123456)
 
     @requests_mock.mock()
+    def tests_login_unknown_mfa_type(self, m):
+        """Tests login with unknown MFA type."""
+        m.post(CONST.LOGIN_URL,
+               text=LOGIN.post_response_unknown_mfa_type(), status_code=200)
+
+        # Check that we raise an Exception with an unknown MFA type
+        with self.assertRaises(abodepy.AbodeAuthenticationException):
+            self.abode_no_cred.login(username=USERNAME,
+                                     password=PASSWORD)
+
+    @requests_mock.mock()
     def tests_logout_failure(self, m):
         """Test logout failed."""
         m.post(CONST.LOGIN_URL, text=LOGIN.post_response_ok())

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = build, py35, py36, py37, lint
+envlist = build, py35, py36, py37, py38, lint
 skip_missing_interpreters = True
 skipsdist = True
 


### PR DESCRIPTION
First attempt at adding MFA support. Overview of changes:
-  Added --mfa argument to the CLI which allows the user to provide a MFA code for login.
- Since Abode uniquely identifies clients by a combination of the UUID and a session cookie, I modified the cache to persist session cookies to disk after successfully logging in and loading it back into requests.session during initialization. 
- Added some constants and error for MFA
- I had to modify the CLI logic a little bit for when a MFA code is provided. I decided against adding mfa_code as an argument and a property to the Abode class since the code is very time sensitive and there's no guarantee that it'll be used for login immediately in that fashion. If the user provides a MFA code, we'll log in using the login() function first before fetching devices from Abode. 
