### PR TITLE
Add Outdoor Smart Cam device

### DIFF
--- a/abodepy/helpers/constants.py
+++ b/abodepy/helpers/constants.py
@@ -167,6 +167,7 @@ DEVICE_MOTION_CAMERA = 'device_type.ir_camera'
 DEVICE_MOTION_VIDEO_CAMERA = 'device_type.ir_camcoder'
 DEVICE_IP_CAM = 'device_type.ipcam'
 DEVICE_OUTDOOR_MOTION_CAMERA = 'device_type.out_view'
+DEVICE_OUTDOOR_SMART_CAMERA = 'device_type.vdp'
 
 # Covers
 DEVICE_SECURE_BARRIER = 'device_type.secure_barrier'
@@ -236,6 +237,7 @@ def get_generic_type(type_tag):
         DEVICE_MOTION_VIDEO_CAMERA: TYPE_CAMERA,
         DEVICE_IP_CAM: TYPE_CAMERA,
         DEVICE_OUTDOOR_MOTION_CAMERA: TYPE_CAMERA,
+        DEVICE_OUTDOOR_SMART_CAMERA: TYPE_CAMERA,
 
         # Covers
         DEVICE_SECURE_BARRIER: TYPE_COVER,


### PR DESCRIPTION
I got the new Outdoor Smart Cam (video doorbell) last week and it didn't show up in devices as it's a new device type, `device_type.vdp`. This PR adds the new device type to be used like the other cameras.