### PR TITLE
Fix enabling/disabling automations.

### DIFF
--- a/abodepy/__main__.py
+++ b/abodepy/__main__.py
@@ -324,7 +324,7 @@ def call():
             automation = abode.get_automation(automation_id)
 
             if automation:
-                if automation.set_active(True):
+                if automation.enable(True):
                     _LOGGER.info(
                         "Activated automation with id: %s", automation_id)
             else:
@@ -336,7 +336,7 @@ def call():
             automation = abode.get_automation(automation_id)
 
             if automation:
-                if automation.set_active(False):
+                if automation.enable(False):
                     _LOGGER.info(
                         "Deactivated automation with id: %s", automation_id)
             else:


### PR DESCRIPTION
I noticed that enabling/disabling automations was broken as 'set_active' method was renamed to 'enable'. With this change, I'm able to enable/disable the Abode automations.

Without this change:
$ abodepy -u ... -p ... --deactivate xxx
2021-05-10 10:51:52 INFO (MainThread) [abodepy] Updating all devices...
2021-05-10 10:51:52 INFO (MainThread) [abodepy] Login successful
2021-05-10 10:51:52 INFO (MainThread) [abodepy] Updating all automations...
2021-05-10 10:51:53 INFO (MainThread) [abodepy] Logout successful
Traceback (most recent call last):
  File "/home/sarvjeet/.local/bin/abodepy", line 8, in <module>
    sys.exit(main())
  File "/home/sarvjeet/.local/lib/python3.8/site-packages/abodepy/__main__.py", line 454, in main
    call()
  File "/home/sarvjeet/.local/lib/python3.8/site-packages/abodepy/__main__.py", line 339, in call
    if automation.set_active(False):
AttributeError: 'AbodeAutomation' object has no attribute 'set_active'
$

With this change:
$ abodepy -u ... -p ... --deactivate xxx
2021-05-10 22:09:33 INFO (MainThread) [abodepy] Updating all devices...
2021-05-10 22:09:33 INFO (MainThread) [abodepy] Login successful
2021-05-10 22:09:33 INFO (MainThread) [abodepy] Updating all automations...
2021-05-10 22:09:33 INFO (MainThread) [abodepy.automation] Set automation XXX enable to: False
2021-05-10 22:09:33 INFO (MainThread) [abodecl] Deactivated automation with id: xxx
2021-05-10 22:09:34 INFO (MainThread) [abodepy] Logout successful
$

Thanks.